### PR TITLE
✨ - Send a query to configured database.

### DIFF
--- a/stardog-query-runner/.gitignore
+++ b/stardog-query-runner/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode-test/

--- a/stardog-query-runner/extension.js
+++ b/stardog-query-runner/extension.js
@@ -3,12 +3,18 @@ const vscode = require('vscode');
 
 const { log } = require('./lib/log');
 
-const { window, workspace } = vscode;
+const { window, workspace, commands } = vscode;
+
+const { Connection } = require('stardog');
 
 const CONFIG_SECTION = 'stardog';
 
-function validateSettings(config = {}) {
-  const settings = ['endpoint', 'username', 'password'];
+// We want to keep a handle to this in case we ever need to
+// dispose of the old one, and add a new one in it's place
+let onSendQuery = null;
+
+const validateSettings = (config = {}) => {
+  const settings = ['endpoint', 'username', 'password', 'database'];
   const errors = [];
 
   settings.forEach((item) => {
@@ -19,32 +25,73 @@ function validateSettings(config = {}) {
   });
 
   return errors.length ? errors : null;
-}
+};
+
+const buildConnection = (config = {}) => {
+  const {
+    endpoint,
+    username,
+    password,
+  } = config;
+  const conn = new Connection();
+  try {
+    conn.setEndpoint(endpoint);
+    conn.setCredentials(username, password);
+  } catch (e) {
+    return null;
+  }
+  return conn;
+};
+
+const sendQuery = (win, conn, database) => {
+  const editor = win.activeTextEditor;
+  if (!editor || !conn) { return; }
+
+  const doc = editor.document;
+  const query = doc.getText();
+
+  conn.query({
+    query,
+    database,
+  }, (body) => {
+    if (body.results) {
+      win.showInformationMessage(`We got ${body.results.bindings.length} bindings back.`);
+    } else {
+      win.showErrorMessage(body);
+    }
+  });
+};
 
 // this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
-function activate(context) {
+const activate = (context) => {
   log('Congratulations, your extension "stardog-query-runner" is now active!');
-  const errors = validateSettings(workspace.getConfiguration(CONFIG_SECTION));
+  const config = workspace.getConfiguration(CONFIG_SECTION);
+  const errors = validateSettings(config);
+
   if (errors) {
     window.showErrorMessage(`Missing required setting${errors.length > 1 ? '(s)' : ''}: [${errors.join(', ')}]`, 'Open "settings.json"').then(() => {
     // TODO: Do something here to show the settings panel so the user can change
       console.log('callback');
     });
-  }
-  // const disposable = commands.registerCommand('extension.sayHello', () => {
-  //   window.showInformationMessage('Hello World!');
-  // });
 
-  // context.subscriptions.push(disposable);
-}
+    // If the settings aren't valid, still create the command, but make it a no-op
+    // This is to prevent errors from happening on menu items and pallet commands
+    onSendQuery = commands.registerCommand('stardog-query-runner.sendQuery', () => {});
+  } else {
+    onSendQuery = commands.registerCommand('stardog-query-runner.sendQuery', () => sendQuery(window, buildConnection(config), config.database));
+  }
+
+  context.subscriptions.push(onSendQuery);
+};
 
 // this method is called when your extension is deactivated
-function deactivate() {
-}
+const deactivate = () => {
+};
 
 module.exports = {
   activate,
+  buildConnection,
   deactivate,
+  sendQuery,
   validateSettings,
 };

--- a/stardog-query-runner/package.json
+++ b/stardog-query-runner/package.json
@@ -15,6 +15,12 @@
   ],
   "main": "./extension",
   "contributes": {
+    "commands": [
+      {
+        "command": "stardog-query-runner.sendQuery",
+        "title": "Execute query"
+      }
+    ],
     "configuration": {
       "title": "Stardog Query Runner Settings",
       "properties": {
@@ -28,12 +34,24 @@
           "default": null,
           "description": "User name to authenticate to the database."
         },
+        "stardog.database": {
+          "type": "string",
+          "default": null,
+          "description": "Database name to query."
+        },
         "stardog.password": {
           "type": "string",
           "default": null,
           "description": "Password to use to authenticate to the database."
         }
       }
+    },
+    "menus": {
+      "editor/title": [
+        {
+          "command": "stardog-query-runner.sendQuery"
+        }
+      ]
     }
   },
   "scripts": {
@@ -48,7 +66,11 @@
     "eslint-plugin-import": "2.2.0",
     "mocha": "2.3.3",
     "must": "0.13.4",
+    "simple-mock": "0.7.3",
     "typescript": "2.0.3",
     "vscode": "1.0.0"
+  },
+  "dependencies": {
+    "stardog": "0.3.1"
   }
 }


### PR DESCRIPTION
Closes #8

Adds a menu item (for now) that will send the entire contents of
a file to the configured database. Will show result count for
this current version.

![sending-query](https://cloud.githubusercontent.com/assets/1591483/23267863/0211dffc-f9ba-11e6-83c7-77bf066dde5a.gif)

```bash
  stardog-query-runner extension
    validateSettings()

vscode-icons is active!

Congratulations, your extension "stardog-query-runner" is now active!

      ✓ returns a list of errors if there are no settings
      ✓ returns specific errors
      ✓ returns null if there are no errors with the settings

    buildConnection

      ✓ buils a Stardog connection based on the supplied settings
      ✓ gracefully handles empty config

    sendQuery()

      ✓ does nothing if there is not an active textEditor
      ✓ does nothing if there is not an active connection
      ✓ sends the query from the window object

  8 passing (21ms)
```
