### PR TITLE
✨ - Highlight and run query

### DIFF
--- a/stardog-query-runner/extension.js
+++ b/stardog-query-runner/extension.js
@@ -113,7 +113,7 @@ const sendQuery = (win, conn, database, provider) => {
   if (!editor || !conn) { return; }
 
   const doc = editor.document;
-  const query = doc.getText();
+  const query = doc.getText(editor.selection.isEmpty ? undefined : editor.selection);
 
   conn.query({
     query,


### PR DESCRIPTION
Closes #12

Now you can highlight a query in the editor and run that so you
can work with multiple queries at a time.

![results](https://cloud.githubusercontent.com/assets/1591483/23556187/bac2c18e-fff9-11e6-9f9b-28ab51462333.gif)
