### PR TITLE
🔨 - improve sparql grammar

### DIFF
--- a/stardog-rdf-grammars/syntaxes/sparql.tmLanguage.json
+++ b/stardog-rdf-grammars/syntaxes/sparql.tmLanguage.json
@@ -22,11 +22,11 @@
       "match": "\\b(?i:concat|regex|asc|desc|bound|isiri|isuri|isblank|isliteral|isnumeric|str|lang|datatype|sameterm|langmatches|avg|count|group_concat|separator|max|min|sample|sum|iri|uri|bnode|strdt|uuid|struuid|strlang|strlen|substr|ucase|lcase|strstarts|strends|contains|strbefore|strafter|encode_for_uri|replace|abs|round|ceil|floor|rand|now|year|month|day|hours|minutes|seconds|timezone|tz|md5|sha1|sha256|sha384|sha512|coalesce|if)\\b"
     },
     "variables": {
-      "name": "variable.other.sparql",
+      "name": "constant.variable.sparql.turtle",
       "match": "(?<!\\w)[?$]\\w+"
     },
     "expression-operators": {
-      "name": "keyword.operator.sparql",
+      "name": "support.class.sparql",
       "match": "(?:\\|\\||&&|=|!=|<|>|<=|>=|\\*|\/|\\+|-|\\||\\^|\\?|\\!)"
     }
   }

--- a/stardog-rdf-grammars/syntaxes/turtle.tmLanguage.json
+++ b/stardog-rdf-grammars/syntaxes/turtle.tmLanguage.json
@@ -17,11 +17,11 @@
   "uuid": "230498230498sdfkj8909-34df-23dfs",
   "repository": {
     "prefix": {
-      "name": "keyword.turtle",
+      "name": "keyword.operator.turtle",
       "match": "(?i:@?base|@?prefix)\\s"
     },
     "iriref": {
-      "name": "string.iri.turtle",
+      "name": "entity.name.type.iriref.turtle",
       "match": "<[^\\x20-\\x20<>\"{}|^`\\\\]*>"
     },
     "prefixed-name": {
@@ -29,10 +29,10 @@
       "match": "(\\w*:)(\\w*)",
       "captures": {
         "1": {
-          "name": "constant.other.turtle"
+          "name": "storage.type.PNAME_NS.turtle"
         },
         "2": {
-          "name": "entity.name.class.turtle"
+          "name": "support.variable.PN_LOCAL.turtle"
         }
       }
     },

--- a/stardog-rdf-grammars/test/test.rq
+++ b/stardog-rdf-grammars/test/test.rq
@@ -14,7 +14,7 @@ WHERE {
                  foaf:familyName ?family }
   } UNION {
     ?c !foaf:knows/foaf:knows? ?thing.
-    ?thing rdfs
+    ?thing
   } MINUS {
     ?thing rdfs:label "剛柔流"@jp
   }


### PR DESCRIPTION
Inherit SPARQL grammar rules from Turtle and improve color scheme to be more aesthetically sensible.