### PR TITLE
🎨 - split stardog mapping syntax into separate grammar

### DIFF
--- a/stardog-rdf-grammars/package.json
+++ b/stardog-rdf-grammars/package.json
@@ -58,8 +58,8 @@
       },
       {
         "language": "stardog-mapping-syntax",
-        "scopeName": "source.turtle",
-        "path": "./syntaxes/turtle.tmLanguage.json"
+        "scopeName": "source.sms",
+        "path": "./syntaxes/stardog-mapping.tmLanguage.json"
       }
     ]
   }

--- a/stardog-rdf-grammars/syntaxes/stardog-mapping.tmLanguage.json
+++ b/stardog-rdf-grammars/syntaxes/stardog-mapping.tmLanguage.json
@@ -1,0 +1,11 @@
+{
+  "name": "Stardog Mapping Syntax",
+  "scopeName": "source.sms",
+  "fileTypes": [
+    "sms"
+  ],
+  "patterns": [
+    { "include": "source.turtle" }
+  ], 
+  "uuid": "92374892374-234d-d87520935"
+}


### PR DESCRIPTION
Inherit Stardog Mapping Syntax from Turtle and split grammar file into separate file.