### PR TITLE
🐛 - Fixed light theme icon

### DIFF
--- a/stardog-query-runner/package.json
+++ b/stardog-query-runner/package.json
@@ -21,7 +21,7 @@
         "title": "Stardog: Execute query",
         "icon": {
           "dark": "./static/white.svg",
-          "light": "./static.black.svg"
+          "light": "./static/black.svg"
         }
       },
       {


### PR DESCRIPTION
Closes #43

Fixed path to the light theme icon, which is the dark colored
rocketship.

![image](https://cloud.githubusercontent.com/assets/1591483/23961758/53156cb6-0982-11e7-869d-bf3af868deb6.png)
