### PR TITLE
🚧 - TypeScript setup. Extension code.

### DIFF
--- a/stardog-query-runner/.gitignore
+++ b/stardog-query-runner/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode-test/
+out

--- a/stardog-rdf-grammars/.gitignore
+++ b/stardog-rdf-grammars/.gitignore
@@ -1,0 +1,2 @@
+out
+node_modules

--- a/stardog-rdf-grammars/.vscode/launch.json
+++ b/stardog-rdf-grammars/.vscode/launch.json
@@ -1,4 +1,4 @@
-// A launch configuration that launches the extension inside a new window
+// A launch configuration that compiles the extension and then opens it inside a new window
 {
     "version": "0.1.0",
     "configurations": [
@@ -7,16 +7,22 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-            "stopOnEntry": false
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
+            "preLaunchTask": "npm"
         },
         {
             "name": "Launch Tests",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/test" ],
-            "stopOnEntry": false
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
+            "preLaunchTask": "npm"
         }
     ]
 }

--- a/stardog-rdf-grammars/.vscode/tasks.json
+++ b/stardog-rdf-grammars/.vscode/tasks.json
@@ -1,0 +1,30 @@
+// Available variables which can be used inside of strings.
+// ${workspaceRoot}: the root folder of the team
+// ${file}: the current opened file
+// ${fileBasename}: the current opened file's basename
+// ${fileDirname}: the current opened file's dirname
+// ${fileExtname}: the current opened file's extension
+// ${cwd}: the current working directory of the spawned process
+
+// A task runner that calls a custom npm script that compiles the extension.
+{
+    "version": "0.1.0",
+
+    // we want to run npm
+    "command": "npm",
+
+    // the command is a shell script
+    "isShellCommand": true,
+
+    // show the output window only if unrecognized errors occur.
+    "showOutput": "silent",
+
+    // we run the custom script "compile" as defined in package.json
+    "args": ["run", "compile", "--loglevel", "silent"],
+
+    // The tsc compiler is started in watching mode
+    "isBackground": true,
+
+    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+    "problemMatcher": "$tsc-watch"
+}

--- a/stardog-rdf-grammars/.vscodeignore
+++ b/stardog-rdf-grammars/.vscodeignore
@@ -1,0 +1,9 @@
+.vscode/**
+.vscode-test/**
+out/test/**
+test/**
+src/**
+**/*.map
+.gitignore
+tsconfig.json
+vsc-extension-quickstart.md

--- a/stardog-rdf-grammars/package.json
+++ b/stardog-rdf-grammars/package.json
@@ -4,6 +4,26 @@
   "description": "Syntax highlighting for SPARQL, Turtle, Stardog Rules Syntax, and other RDF languages",
   "version": "0.0.1",
   "publisher": "stardog-union",
+  "scripts": {
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "typescript": "^2.0.3",
+    "vscode": "^1.0.5",
+    "mocha": "^2.3.3",
+    "@types/node": "^6.0.40",
+    "@types/mocha": "^2.2.32"
+  },
+  "main": "./out/src/extension",
+  "activationEvents": [
+    "onLanguage:sparql",
+    "onLanguage:turtle",
+    "onLanguage:stardog-mapping-syntax",
+    "onLanguage:stardog-rules-syntax"
+  ],
   "engines": {
     "vscode": "^1.5.0"
   },
@@ -23,7 +43,8 @@
           ".sparql"
         ],
         "configuration": "./language-configuration.json"
-      }, {
+      },
+      {
         "id": "turtle",
         "aliases": [
           "TURTLE",
@@ -34,7 +55,8 @@
           ".turtle"
         ],
         "configuration": "./language-configuration.json"
-      }, {
+      },
+      {
         "id": "stardog-mapping-syntax",
         "aliases": [
           "Stardog Mapping Syntax"
@@ -43,7 +65,8 @@
           ".sms"
         ],
         "configuration": "./language-configuration.json"
-      }, {
+      },
+      {
         "id": "stardog-rules-syntax",
         "aliases": [
           "Stardog Rules Syntax"

--- a/stardog-rdf-grammars/src/extension.ts
+++ b/stardog-rdf-grammars/src/extension.ts
@@ -1,0 +1,8 @@
+import * as vscode from 'vscode';
+import SPARQLFormatter from './providers/sparqlformatter';
+
+export function activate(context: vscode.ExtensionContext) {
+  console.log('activate');
+  context.subscriptions.push(
+    vscode.languages.registerDocumentFormattingEditProvider(['sparql'], new SPARQLFormatter()));
+};

--- a/stardog-rdf-grammars/src/providers/sparqlformatter.ts
+++ b/stardog-rdf-grammars/src/providers/sparqlformatter.ts
@@ -1,0 +1,17 @@
+import * as vscode from 'vscode';
+
+// `{`, `[`, `;` will have a new line after them (but not before) and next line will be indented, 
+// `]` and `}` should start a new line aligned with the block of the matching character
+export default class SPARQLFormatter implements vscode.DocumentFormattingEditProvider {
+  /**
+   * provideDocumentFormattingEdits
+   */
+  public provideDocumentFormattingEdits(
+    document: vscode.TextDocument,
+    options: vscode.FormattingOptions,
+    token: vscode.CancellationToken): Thenable<vscode.TextEdit[]> {
+    return new Promise((resolve, reject) => {
+      const text = document.getText();
+    });
+  }
+}

--- a/stardog-rdf-grammars/tsconfig.json
+++ b/stardog-rdf-grammars/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "out",
+        "lib": [
+            "es6"
+        ],
+        "sourceMap": true,
+        "rootDir": "."
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ]
+}


### PR DESCRIPTION
Set up for the basic plumbing for a TypeScript extension. Added
logic to register this extension on the supplied languages.
Stubbed in a formatting provider that doesn't do anything yet.