### PR TITLE
Add sq extension for sparql

### DIFF
--- a/stardog-rdf-grammars/CHANGELOG.md
+++ b/stardog-rdf-grammars/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to the "stardog-rdf-grammars" extension will be documented in this file.
 
+## [0.1.3] - 2021-07-08
+### Added
+- `.sq` extension for sparql
+
 ## [0.1.2]
 - Update highlighting for new grammars
 

--- a/stardog-rdf-grammars/package.json
+++ b/stardog-rdf-grammars/package.json
@@ -3,7 +3,7 @@
   "publisher": "stardog-union",
   "displayName": "Stardog RDF Grammars",
   "description": "Syntax highlighting for SPARQL, Turtle, Stardog Rules Syntax, and other RDF languages",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "contributors": [
     {
@@ -43,7 +43,8 @@
         ],
         "extensions": [
           ".rq",
-          ".sparql"
+          ".sparql",
+          ".sq"
         ],
         "configuration": "./language-configuration.json"
       },

--- a/stardog-rdf-grammars/syntaxes/sparql.tmLanguage.json
+++ b/stardog-rdf-grammars/syntaxes/sparql.tmLanguage.json
@@ -3,7 +3,8 @@
   "scopeName": "source.sparql",
   "fileTypes": [
     "rq",
-    "sparql"
+    "sparql",
+    "sq"
   ],
   "patterns": [
     { "include": "source.turtle" },


### PR DESCRIPTION
On our NASA project, we have a lot of `.sq` extension for sparql queries.  I'd like to include `.sq` extension.