### PR TITLE
feat: add .acl to turtle file extensions

### DIFF
--- a/stardog-rdf-grammars/package.json
+++ b/stardog-rdf-grammars/package.json
@@ -55,7 +55,8 @@
         ],
         "extensions": [
           ".ttl",
-          ".turtle"
+          ".turtle",
+          ".acl"
         ],
         "configuration": "./language-configuration.json"
       },

--- a/stardog-rdf-grammars/syntaxes/turtle.tmLanguage.json
+++ b/stardog-rdf-grammars/syntaxes/turtle.tmLanguage.json
@@ -3,7 +3,8 @@
   "scopeName": "source.turtle",
   "fileTypes": [
     "turtle",
-    "ttl"
+    "ttl",
+    "acl"
   ],
   "patterns": [
     { "include": "#rule-constraint" },


### PR DESCRIPTION
This PR adds `.acl` to the Turtle syntax list to allow syntax highlighting of Solid access controls.

This was based on an issue opened in the downstream repo for the linked-data vscode extension https://github.com/elsevierlabs-os/linked-data/issues/3 .