### PR TITLE
changing order of string literals in ttl grammar

### DIFF
--- a/stardog-rdf-grammars/syntaxes/turtle.tmLanguage.json
+++ b/stardog-rdf-grammars/syntaxes/turtle.tmLanguage.json
@@ -59,10 +59,10 @@
     },
     "string": {
       "patterns": [
-        { "include": "#single-squote-string-literal" },
-        { "include": "#single-dquote-string-literal" },
         { "include": "#triple-squote-string-literal" },
         { "include": "#triple-dquote-string-literal" },
+        { "include": "#single-squote-string-literal" },
+        { "include": "#single-dquote-string-literal" },
         { "include": "#triple-tick-string-literal" }
       ]
     },


### PR DESCRIPTION
At least in my tests, the prior ordering means that `"""` is always recognized as 3 individual `single-dquote-string-literal` instead of a single `triple-dquote-string-literal`. (Likely not an issue when styling, but still :-) )